### PR TITLE
Feature/hi/issue 267

### DIFF
--- a/packages/backend/db/test_db.js
+++ b/packages/backend/db/test_db.js
@@ -1,0 +1,32 @@
+const mysql = require('mysql');
+const path = require("path");
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.join(__dirname, './.env') })
+
+const config = {
+    host: 'localhost',
+    port: '3306',
+    user: 'root',
+    password: process.env.PASSWORD,
+    database: ''
+}
+
+const connect = mysql.createConnection(config);
+
+const test_db_connect = function(con){
+    con.connect(function(err){
+        if(err){
+            console.error('mysql connection error :' + err);
+        }else {
+            console.info('mysql is connected successfully.')
+        }
+    })
+}
+
+test_db_connect(connect);
+
+
+module.exports = {
+    text_db_connect: connect
+}

--- a/packages/backend/db/test_db.js
+++ b/packages/backend/db/test_db.js
@@ -12,21 +12,18 @@ const config = {
     database: ''
 }
 
-const connect = mysql.createConnection(config);
-
-const test_db_connect = function(con){
-    con.connect(function(err){
-        if(err){
-            console.error('mysql connection error :' + err);
-        }else {
-            console.info('mysql is connected successfully.')
-        }
-    })
-}
-
-test_db_connect(connect);
-
-
 module.exports = {
-    text_db_connect: connect
+    connect: mysql.createConnection(config),
+    createDB: con => {
+        con.connect('CREATE DATABASE test_nyangterest',(err, result)=>{
+            if(err) console.log('mysql error create:'+err)
+            console.log('SUCCESS DATABASE TEST CREATE!')
+        })
+    },
+    dropDB: con => {
+        con.connect('DROP DATABASE test_nyangterest',(err, result)=>{
+            if(err) console.log('mysql error drop:'+err)
+            console.log('SUCCESS DATABASE TEST DROP!')
+        })
+    },
 }

--- a/packages/backend/join.js
+++ b/packages/backend/join.js
@@ -31,6 +31,9 @@ connection.connect();
 const existUserEmail = (req, res) => {
     // url로 받아온 유저이메일
     const useremail = req.params.useremail;
+    // default value = null
+    const snsName = req.params.snsName || null;
+
     // 유저 이메일 중복 검사
     connection.query(
         `SELECT * FROM nyang_member WHERE email='${useremail}'`,
@@ -38,10 +41,19 @@ const existUserEmail = (req, res) => {
             if (err) {
                 res.send("error");
             } else {
-                // useremail 검색한 결과가 1개라도 나오면 true 보낸다
-                // true : 중복있음
-                // false : 중복없음
-                res.send(rows.length >= 1);
+                // 같은 이메일 주소를 갖고있는 rows(array)를 가져와 params로 받은 snsName로 filtering하여 조건에 해당되는 배열을 return 한다.
+                // 해당 배열의 length가 0 보다 크면 중복이 있기때문에 true return
+                // true = 계정 있음 , false = 계정 없음
+                // 가입이 가능한 경우 (false return)
+                // 1. rows가 없는 경우
+                // 2. snsName과 일치하는 배열이 없는 경우
+                const isExist =
+                    rows.length > 0 ||
+                    rows.filter(function (item) {
+                        return item.snsName === snsName;
+                    }).length > 0;
+
+                res.send(isExist);
             }
         }
     );

--- a/packages/backend/join.js
+++ b/packages/backend/join.js
@@ -62,10 +62,11 @@ const existUserEmail = (req, res) => {
 const resistUser = async (req, res) => {
     const resistUserInfo = {
         email: req.body.email,
-        password: await bcryptjs.hash(req.body.password, 10),
+        password: req.body.password ? await bcryptjs.hash(req.body.password, 10) : null,
         signupdate: moment().format("YYYYMMDD"),
-        certify: false,
+        certify: req.body.certify || false,
         emailToken: await bcryptjs.hash(EMAIL_CERTIFY_KEY, 10),
+        snsName: req.body.snsName || null
     };
 
     const emailLink = `http://localhost:8080/user/join/welcome?email=${resistUserInfo.email}&token=${resistUserInfo.emailToken}`;
@@ -80,7 +81,7 @@ const resistUser = async (req, res) => {
     // 회원 가입 처리 query
     // 회언 정보 DB저장
     const sql =
-        "INSERT INTO `nyang_member` (`email`, `password`, `signupdate`, `certify`, `token`) VALUES ( ?,?,?,?,? )";
+        "INSERT INTO `nyang_member` (`email`, `password`, `signupdate`, `certify`, `token`, `snsName`) VALUES ( ?,?,?,?,?,? )";
     const params = ((resistUserInfo) => {
         let resistUserInfoArray = [];
         for (items in resistUserInfo) {
@@ -95,8 +96,12 @@ const resistUser = async (req, res) => {
             console.log("회원가입 실패", err);
             res.send(false);
         } else {
-            // 회원가입 인증 메일 발송
-            mailSender.sendGmail(mailSenderOption);
+            if(resistUserInfo.snsName === null) {
+                 // 회원가입 인증 메일 발송
+                mailSender.sendGmail(mailSenderOption);
+                // 회원가입 성공 여부 front로 보내기
+                res.send(true);
+            }
             // 회원가입 성공 여부 front로 보내기
             res.send(true);
         }

--- a/packages/backend/oauth.js
+++ b/packages/backend/oauth.js
@@ -3,8 +3,9 @@
 const fs = require("fs");
 const express = require("express");
 const router = express.Router();
+const path = require("path");
 const passport = require("passport");
-const session = require("express-session");
+// const session = require("express-session");
 // const FileStore = require("session-file-store")(session);
 const GoogleStrategy = require("passport-google-oauth20").Strategy;
 const dotenv = require('dotenv');
@@ -92,17 +93,30 @@ passport.use(
                 }
             
                 // else 회원가입 처리 예시
-                // const response = await fetch(
-                //     '/user/join'
-                // ,{
-                //     headers: {
-                //     Accept: "application/json",
-                //     "Content-Type": "application/json",
-                //     },
-                //     method: "POST",
-                //     body: sendAccountInfo,
-                // });
-                // const json = await response.json();
+                const joinData = {
+                    email: profile._json.email,
+                    snsName: profile.provider,
+                    // email: 'henyy1004@naver.com',
+                    // snsName: 'google',
+                    password: null,
+                    certify: true,
+                }
+                const joinResponse = await fetch(
+                    '/user/join'
+                ,{
+                    headers: {
+                    Accept: "application/json",
+                    "Content-Type": "application/json",
+                    },
+                    method: "POST",
+                    body: JSON.stringify(joinData), 
+                });
+                const joinJson = await joinResponse.json();
+
+                if(!joinJson) {
+                    return done(null);
+                }
+                
                 return done(null, profile);
             }
             

--- a/packages/backend/oauth.js
+++ b/packages/backend/oauth.js
@@ -64,6 +64,49 @@ passport.use(
         },
         async function (accessToken, refreshToken, profile, done) {
             console.log("profile:", profile);
+
+            // profile이 있다면 (인증에 성공해 회원정보가 넘어옴)
+            if (profile) {
+                const response = await fetch(
+                    // 소셜 서비스 정보도 같이 보내야됨
+                    // post요청으로 json객체에 담아 보내기
+                    // `/user/exists/email/${profile._json.email}/${profile.provider}`
+                    `/user/exists/email/${profile._json.email}/`
+                );
+                const json = await response.json();
+            
+                // 이메일이 중복된다면
+                if (json) {
+                    // 로그인 처리 예시
+                    // const response = await fetch(
+                    //     '/login'
+                    // ,{
+                    //     headers: {
+                    //     Accept: "application/json",
+                    //     "Content-Type": "application/json",
+                    //     },
+                    //     method: "POST",
+                    //     body: sendAccountInfo,
+                    // });
+                    // const json = await response.json();
+                }
+            
+                // else 회원가입 처리 예시
+                // const response = await fetch(
+                //     '/user/join'
+                // ,{
+                //     headers: {
+                //     Accept: "application/json",
+                //     "Content-Type": "application/json",
+                //     },
+                //     method: "POST",
+                //     body: sendAccountInfo,
+                // });
+                // const json = await response.json();
+                return done(null, profile);
+            }
+            
+            return done(null);
         }
     )
 );

--- a/packages/backend/oauth.js
+++ b/packages/backend/oauth.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const fs = require("fs");
+const express = require("express");
+const router = express.Router();
+const passport = require("passport");
+const session = require("express-session");
+// const FileStore = require("session-file-store")(session);
+const GoogleStrategy = require("passport-google-oauth20").Strategy;
+const dotenv = require('dotenv');
+dotenv.config({ path: path.join(__dirname, './.env') })
+
+// db접속
+const data = fs.readFileSync(__dirname + "/db.json");
+const conf = JSON.parse(data);
+const mysql = require("mysql");
+const { default: fetch } = require("node-fetch");
+
+// 환경설정 연결 초기화
+const connection = mysql.createConnection({
+    host: conf.host,
+    user: conf.user,
+    password: conf.password,
+    port: conf.port,
+    database: conf.database,
+});
+
+connection.connect();
+
+// router.use(
+//     session({
+//         name: "nyangterest_session",
+//         secure: true,
+//         secret: "abcde",
+//         resave: false,
+//         saveUninitialized: true,
+//         store: new FileStore(),
+//         cookie: { secure: true },
+//     })
+// ); // 세션 활성화
+
+// router.use(passport.initialize()); // passport 구동
+// router.use(passport.session()); // 세션 연결
+
+passport.serializeUser(function (user, done) {
+    done(null, user);
+});
+
+passport.deserializeUser(function (obj, done) {
+    done(null, obj);
+});
+
+// strategy 구성
+// google
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+
+passport.use(
+    new GoogleStrategy(
+        {
+            clientID: GOOGLE_CLIENT_ID,
+            clientSecret: GOOGLE_CLIENT_SECRET,
+            callbackURL: "/auth/google/callback",
+        },
+        async function (accessToken, refreshToken, profile, done) {
+            console.log("profile:", profile);
+        }
+    )
+);
+
+router.get(
+    "/google",
+    passport.authenticate("google", {
+        scope: [
+            "https://www.googleapis.com/auth/userinfo.profile",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ],
+        accessType: "offline",
+        prompt: "select_account",
+    }),
+    function (req, res) {
+        console.log("1. req /google:", req, "req end");
+    }
+);
+
+router.get(
+    "/google/callback",
+    passport.authenticate("google", {
+        failureRedirect: "http://localhost:3000/join/welcome/1234",
+        session: false,
+    }),
+    (req, res) => {
+        // Successful authentication, redirect home.
+        res.redirect("http://localhost:3000/");
+    }
+);
+
+module.exports = router;

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -14,6 +14,8 @@
 		"node-fetch": "^2.4.1",
 		"nodemailer": "^6.3.1",
 		"passport": "^0.4.0",
+		"passport-google-oauth": "^2.0.0",
+		"passport-google-oauth20": "^2.0.0",
 		"passport-local": "^1.0.0",
 		"path": "^0.12.7",
 		"request": "^2.88.0",

--- a/packages/backend/server.js
+++ b/packages/backend/server.js
@@ -10,9 +10,10 @@ const login = require('./login');
 const memberInfo = require('./memberInfo');
 const findAccount = require('./findAccount');
 const join = require('./join');
-const logger = require('./winston')
-const unregister = require('./unregister')
-const dotenv = require('dotenv')
+const logger = require('./winston');
+const unregister = require('./unregister');
+const dotenv = require('dotenv');
+const oauth = require('./oauth');
 
 dotenv.config({ path: path.join(__dirname, './.env') })
 
@@ -145,6 +146,8 @@ app.use("/admin/member", router);
 app.use("/", join);
 // 로그인 미들웨어
 app.use("/", login);
+// oauth 로그인 미들웨어
+app.use("/auth", oauth);
 // 회원정보 수정 미들웨어
 app.use("/", memberInfo);
 // 계정찾기 미들웨어

--- a/packages/backend/test/join.test.js
+++ b/packages/backend/test/join.test.js
@@ -1,0 +1,76 @@
+const request = require('supertest');
+const server = require('../join');
+const fs = require("fs");
+const moment = require("moment");
+const bcryptjs = require("bcryptjs");
+const dotenv = require("dotenv");
+const path = require("path");
+
+// 환경설정 파일에서 이메일 인증 Secret key 가져오기
+dotenv.config({ path: path.join(__dirname, "./.env") });
+const EMAIL_CERTIFY_KEY = process.env.EMAIL_CERTIFY_KEY;
+
+
+// db접속
+const data = fs.readFileSync(__dirname + "../db.json");
+const conf = JSON.parse(data);
+const mysql = require("mysql");
+
+// 환경설정 연결 초기화
+const connection = mysql.createConnection({
+    host: conf.host,
+    user: conf.user,
+    password: conf.password,
+    port: conf.port,
+    database: conf.database,
+});
+
+describe('사용자가 소셜 로그인에 성공', () => {
+	test('중복계정이 없다면 회원가입', async () => {
+		const dumyData = {
+			email: 'henyy1004@naver.com',
+			password: null,
+			signupdate: moment().format("YYYYMMDD"),
+			certify: true,
+			emailToken: await bcryptjs.hash(EMAIL_CERTIFY_KEY, 10),
+			snsName: 'google'
+		};
+
+		const emailLink = `http://localhost:8080/user/join/welcome?email=${dumyData.email}&token=${dumyData.emailToken}`;
+
+    // 메일 발송 params
+    let mailSenderOption = {
+        toEmail: dumyData.email,
+        subject: "냥터레스트 회원가입을 위한 이메일 인증을 부탁드립니다.",
+        text: `안녕하세요 회원가입을 축하드립니다. ${emailLink} 해당 링크로 접속해주시면 인증이 완료되어 냥터레스트에 로그인하실 수 있습니다.`,
+    };
+
+    // 회원 가입 처리 query
+    // 회언 정보 DB저장
+    const sql =
+        "INSERT INTO `nyang_member` (`email`, `password`, `signupdate`, `certify`, `token`, `snsName`) VALUES ( ?,?,?,?,?,? )";
+    const params = ((resistUserInfo) => {
+        let resistUserInfoArray = [];
+        for (items in resistUserInfo) {
+            resistUserInfoArray.push(resistUserInfo[items]);
+        }
+
+			return resistUserInfoArray;
+		})(resistUserInfo);
+
+	const result = connection.query(sql, params, (err, rows) => {
+			if (err) {
+				console.log("회원가입 실패", err);
+				return fals
+			} else {
+				if(resistUserInfo.snsName === null) {
+					return false;
+				}
+
+				return true
+			}
+		});
+		
+		expect(result).toBe(true);
+	})
+})

--- a/packages/frontend/src/Components/popup/LayerJoin.js
+++ b/packages/frontend/src/Components/popup/LayerJoin.js
@@ -286,6 +286,19 @@ class LayerJoin extends Component {
                     >
                         계속하기
                     </Button>
+                    {/* 구글 로그인과 동일함 */}
+                    <a
+                        target='_blank'
+                        href='http://localhost:8080/auth/google'
+                        style={{
+                            margin: 20,
+                            padding: 10,
+                            background: "red",
+                            display: "block",
+                        }}
+                    >
+                        구글 회원가입
+                    </a>
                 </div>
             </div>
         );

--- a/packages/frontend/src/Components/popup/LayerLogin.js
+++ b/packages/frontend/src/Components/popup/LayerLogin.js
@@ -185,6 +185,18 @@ class LayerLogin extends Component {
                     >
                         회원가입
                     </Button>
+                    <a
+                        target='_blank'
+                        href='http://localhost:8080/auth/google'
+                        style={{
+                            margin: 20,
+                            padding: 10,
+                            background: "red",
+                            display: "block",
+                        }}
+                    >
+                        구글 로그인
+                    </a>
                 </div>
             </div>
         );


### PR DESCRIPTION
@jongfeel 

멘토님 안녕하세용 
구글 로그인을 직접 테스트하면서 순서대로 기능처리에대한 확인을 하며 분석과 설계를 수정하고 있는데요
처음에 생각했을때는 일반회원과 소셜회원 로직을 전혀 다른 독립적인 부분으로 생각했다가 직접 테스트를 해보니
기존 로그인,회원가입로직을 이용해 처리를 해야 만들어놓은 계정관련 로직들을 큰 수정없이 사용할 수 있다고 판단이 되었습니다.

그래서 oauth로는 회원 정보만을 가져와서 기존 로그인,회원가입을 사용한 처리를 테스트 하고 있습니다
그런데 하다보니 로직들이 조금씩 소셜로그인의 기준?으로 변경되는 것 같아서 바르게 설계가 되고 있는 것인지 궁금합니다.

아래는 저의 생각의 흐름.....
- 구글 로그인을 테스트하면서 기존 로그인과 회원가입 로직이 조금씩 변경되고 있음
- 일반 회원을 생각하고 만든 코드가 소셜 로그인 로직이랑 섞이고 있음
- snsName이라는 어떤 변수가 추가되어 이 변수를 기준으로 로그인,회원가입 로직이 일반회원/소셜회원으로 분기처리가 된다.
- 자잘하지만 점점 소셜 계정을 기준으로 로직들이 변경된다
- 소셜 계정이 로그인과 회원가입의 기준이 되는 것 같다. 이게 맞나..?

아래 두개의 커밋이 고민중인 부분입니다!
[#267 이메일 중복 체크 후 로그인,회원가입 분기처리](https://github.com/hi-hyein/nyangterest/commit/d0092db7d16e07b2c21e23dc99424542759c603a)
[#267 이메일 중복 코드 소셜서비스명에 따라 분기 처리](https://github.com/hi-hyein/nyangterest/commit/a306fe2860fabee29296f1ffec515d96b531fd43)

